### PR TITLE
Add Dialpad Fast Start for Startups to Cloud Telephony list

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ put your business on the path to transformative growth. Disrupt your industry wi
 - [MyOperator for Startups [INDIA ONLY]](https://myoperator.co/startup-program) - MyOperator’s Startup Program will transform the way you and your team communicates with leads and customers. India’s first end-to-end call management solution comes with exclusive startup program products & features.
 - [Exotel for Startups [INDIA ONLY]](https://exotel.com/cloud-telephony-for-startups/) - Exotel for Startups is a special account for startups that gives you access to all of Exotel’s features.
 - [MSG91 for Startups [INDIA ONLY]](https://msg91.com/startups/) - A startup for startups. Grow your startup with MSG91's SMS for startups. First few transactional bulk SMS free every month.
+- [Dialpad Fast Start](https://www.dialpad.com/solutions/faststart/) - Dialpad and UberConference for free for life. The Fast Start program provides qualified, VC-backed startups with 10 free lifelong seats for Dialpad Pro and UberConference Business.
 
 ### Email Delivery
 


### PR DESCRIPTION
Adding link for the Dialpad Fast Start for startups program: https://www.dialpad.com/solutions/faststart/

> Dialpad and UberConference. For free. For life. 
> The Fast Start program provides qualified, VC-backed startups with 10 free lifelong seats for Dialpad Pro and UberConference Business.

Dialpad Pro offers a full suite of features like unlimited phone, video and messaging as well as many integrations like GSuite, O365, Salesforce, Zendesk and more. We make it easier to get your sales and support teams off the ground.