### PR TITLE
Add Pareto Security's startup discount

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ A collection of awesome companies offering free/discounted plans for eligible st
 - [MATLAB and Simulink for Startups](https://mathworks.com/products/startups.html) - Eligible early stage technology startups can get MATLAB, Simulink, and more than 90 industry-specific toolboxes at a startup-friendly price along with other exclusive benefits.
 - [FeedBear](https://www.feedbear.com/early-stage) – Affordable feedback management for early-stage startups. Eligible startups get all FeedBear features for just $29/mo for up to one year.
 - [Remote for Startups](https://remote.com/startups) - The Remote for Startups Program is designed to help you legally and compliantly employ global talent with world-class payroll, tax, benefits, and compliance solutions. Get access to the same powerful platform, HR experts, and localized legal support, at a fraction of the cost.
-- [Pareto Security for Startups](https://paretosecurity.com/teams) - Automatically audit your team's Macs for basic security hygiene using a privacy-conscious Menu Bar app. Use `STARTUP` at checkout. 
+- [Pareto Security](https://paretosecurity.com/pricing) - A suite of essential macOS security apps for small businesses. Non-invasive alternative to corporate MDM and RMM solutions for small businesses that care about security but know it doesn't have to be invasive for their team members. Use the coupon code `STARTUP` at checkout.
 
 ## Discontinued
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ A collection of awesome companies offering free/discounted plans for eligible st
 - [MATLAB and Simulink for Startups](https://mathworks.com/products/startups.html) - Eligible early stage technology startups can get MATLAB, Simulink, and more than 90 industry-specific toolboxes at a startup-friendly price along with other exclusive benefits.
 - [FeedBear](https://www.feedbear.com/early-stage) – Affordable feedback management for early-stage startups. Eligible startups get all FeedBear features for just $29/mo for up to one year.
 - [Remote for Startups](https://remote.com/startups) - The Remote for Startups Program is designed to help you legally and compliantly employ global talent with world-class payroll, tax, benefits, and compliance solutions. Get access to the same powerful platform, HR experts, and localized legal support, at a fraction of the cost.
+- [Pareto Security for Startups](https://paretosecurity.com/teams) - Automatically audit your team's Macs for basic security hygiene using a privacy-conscious Menu Bar app. Use `STARTUP` at checkout. 
 
 ## Discontinued
 


### PR DESCRIPTION
I realize there is no dedicated startup page, but there is a special code for startups to get the Team plan. And the app is purpose built for small teams & startups, so there's that as well. 