### PR TITLE
Add Argonaut's Startup Tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ A collection of awesome companies offering free/discounted plans for eligible st
 
 ### Miscellaneous
 
+- [Argonaut](https://argonaut.dev/pricing) - Argonaut's forever free startup tier allows unlimited apps and deployments for 5 environments and 2 users. Additional discounts on other tiers available for early-stage startups and OSS maker. Deploy apps and infrastructure on your cloud in minutes. Support for custom and third-party app deployments on Kubernetes and Lambda environments.
 - [Esri Startup Program](https://www.esri.com/en-us/about/esri-partner-network/our-partners/esri-startup-program) - The Esri Startup Program is a global three-year program that helps startups build mapping and location intelligence into their products and businesses.
 - [MATLAB and Simulink for Startups](https://mathworks.com/products/startups.html) - Eligible early stage technology startups can get MATLAB, Simulink, and more than 90 industry-specific toolboxes at a startup-friendly price along with other exclusive benefits.
 - [FeedBear](https://www.feedbear.com/early-stage) – Affordable feedback management for early-stage startups. Eligible startups get all FeedBear features for just $29/mo for up to one year.


### PR DESCRIPTION
Ideal for most startup use cases. We currently support deployments to Lambda and Kubernetes environments on AWS and will be adding GCP and Azure in the future.

Though we do not have a separate startup page yet, our product is created specifically for startup use cases and the pricing page provides a good amount of information about the tier and discounts available. Early-stage startups / OSS projects can reach out for further discounts on other tiers.

https://www.argonaut.dev/