### PR TITLE
Add Rabata Storage Grant to Cloud Computing

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ A collection of awesome companies offering free/discounted plans for eligible st
 - [Clever Bootstrap Program](https://www.clever-cloud.com/en/early-stage) - Clever Cloud is an IT Automation platform. They manage all the ops work while you focus on your business value. The Clever Bootstrap Program provides startups with 90% off on the first three months. Then a 10% discount is applied on your first apps for an unlimited amount of time.
 - [Heroku for Startups Program](https://www.heroku.com/accelerate) - The Heroku for Startups Program provides teams with the resources they need to quickly get started on Heroku—including platform credits, technical support, and networking.
 - [Scaleway Startup Program](https://www.scaleway.com/en/startup-program/) - The Scaleway Startup Program is a time-limited cloud computing partnership program designed for startups. Benefits include access to public cloud infrastructure combined with technical assistance, resources, advisory and advertising.
+- [Rabata Storage Grant](https://rabata.io/grant-application) - Up to $100,000 in S3-compatible storage credits for Gen-AI startups. No VC requirement, no accelerator affiliation, no minimum spend required.
 
 ### Cloud Database
 


### PR DESCRIPTION
Rabata offers up to $100K in storage credits for AI and video startups  with no VC or accelerator requirement - one of the few infrastructure  grants accessible to bootstrapped early-stage teams.

Grant page: https://rabata.io/grant-application